### PR TITLE
Support for modules parameter

### DIFF
--- a/lib/src/quill/quill.dart
+++ b/lib/src/quill/quill.dart
@@ -24,7 +24,7 @@ abstract class QuillOptionsStatic {
   external set theme(String v);
   external factory QuillOptionsStatic(
       {String debug,
-      Map<String, Object> /*JSMap of <String,dynamic>*/ modules,
+      dynamic /*JSMap of <String,dynamic>*/ modules,
       String placeholder,
       bool readOnly,
       String theme});

--- a/lib/src/quill/quill_component.dart
+++ b/lib/src/quill/quill_component.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:html' show Element;
+import 'dart:js_util' show jsify;
 
 import 'package:angular/angular.dart';
 import 'package:angular_forms/angular_forms.dart';
@@ -92,6 +93,9 @@ class QuillComponent implements AfterContentInit, OnDestroy {
   @Input()
   String placeholder = '';
 
+  @Input()
+  dynamic modules = {};
+
   bool _disabled = false;
   bool get disabled => _disabled;
   @Input()
@@ -117,7 +121,12 @@ class QuillComponent implements AfterContentInit, OnDestroy {
   @override
   ngAfterContentInit() {
     quillEditor = new quill.QuillStatic(editor,
-        new quill.QuillOptionsStatic(theme: 'snow', placeholder: placeholder));
+      new quill.QuillOptionsStatic(
+        theme: 'snow',
+        placeholder: placeholder,
+        modules: jsify(modules)
+      )
+    );
     quillEditor.enable(!_disabled);
     quillEditor.pasteHTML(_initialValue);
 


### PR DESCRIPTION
Solves [issue #2](https://github.com/adamlofts/angular_quill/issues/2).
### Example
In **component.html**:
`<quill [modules]="editorOptions"></quill>`

In **component.dart**:
```
Object editorOptions = {
  'toolbar':  [
    [{ 'font': [] },{ 'size': ['small', false, 'large', 'huge'] }],
    ['bold', 'italic', 'underline', 'strike'],
    ['link', 'image', 'video', 'formula'],
  ]
};
```
### Result
![extended Quill editor](https://user-images.githubusercontent.com/16029858/58791372-be262580-85fa-11e9-947a-5d6144853443.png)